### PR TITLE
Added custom color and background color.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,18 +42,18 @@ run the program with the following options (the default zig install directory is
    - `    --full_characters`: Uses full spectrum of characters in image.
    - `    --ascii_chars <string>`: Use what characters you want to use in the image. (default: " .:-=+*%@#")
    - `    --disable_sort`: Prevents sorting of the ascii_chars by size.
-   - `    --block_size <u8>`: Set the size of the blocks. (default: 8)
+   - `    --block_size <int>`: Set the size of the blocks. (default: 8)
    - `    --threshold_disabled`: Disables the threshold.
 
    Advanced color settings:
    - `    --custom_color`: Enables custom color for the image from the --r, --g, --b parameters
-   - `    --r`: Sets the r color.
-   - `    --g`: Sets the g color.
-   - `    --b`: Sets the b color.
+   - `    --r <int>`: Sets the r color.
+   - `    --g <int>`: Sets the g color.
+   - `    --b <int>`: Sets the b color.
    - `    --background_color`: Enables background color for the image from the --r_bg, --g_bg, --b_bg parameters
-   - `    --r_bg`: Sets the r color of the background.
-   - `    --g_bg`: Sets the g color of the background.
-   - `    --b_bg`: Sets the b color of the background.
+   - `    --r_bg <int>`: Sets the r color of the background.
+   - `    --g_bg <int>`: Sets the g color of the background.
+   - `    --b_bg <int>`: Sets the b color of the background.
 
 2. examples:
 

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ run the program with the following options (the default zig install directory is
    ```
    /path/to/asciigen [options]
    ```
-1. options:
+1. Options:
    - `-h, --help`: print the help message and exit
    - `-i, --input <file>`: specify the input image file path (local path/URL) (required)
    - `-o, --output <file>`: specify the output image file (optional, default: `<input>_ascii.jpg`)
@@ -37,19 +37,23 @@ run the program with the following options (the default zig install directory is
    - `    --sigma1 <float>`: set the sigma1 value for DoG filter (optional, default: 0.3)
    - `    --sigma2 <float>`: set the sigma2 value for DoG filter (optional, default: 1.0)
    - `-b, --brightness_boost <float>`: increase/decrease perceived brightness (optional, default: 1.0)
-   
-   advanced options (your image will break, probably, but you might get some cool results):
+
+   Advanced options (your image will break, probably, but you might get some cool results):
    - `    --full_characters`: Uses full spectrum of characters in image.
    - `    --ascii_chars <string>`: Use what characters you want to use in the image. (default: " .:-=+*%@#")
    - `    --disable_sort`: Prevents sorting of the ascii_chars by size.
    - `    --block_size <u8>`: Set the size of the blocks. (default: 8)
    - `    --threshold_disabled`: Disables the threshold.
 
-   set a custom color value
-   - `    --custom_color`: Enables custom color from the --r, --g, --b parameters
+   Advanced color settings:
+   - `    --custom_color`: Enables custom color for the image from the --r, --g, --b parameters
    - `    --r`: Sets the r color.
    - `    --g`: Sets the g color.
    - `    --b`: Sets the b color.
+   - `    --background_color`: Enables background color for the image from the --r_bg, --g_bg, --b_bg parameters
+   - `    --r_bg`: Sets the r color of the background.
+   - `    --g_bg`: Sets the g color of the background.
+   - `    --b_bg`: Sets the b color of the background.
 
 2. examples:
 

--- a/readme.md
+++ b/readme.md
@@ -37,12 +37,19 @@ run the program with the following options (the default zig install directory is
    - `    --sigma1 <float>`: set the sigma1 value for DoG filter (optional, default: 0.3)
    - `    --sigma2 <float>`: set the sigma2 value for DoG filter (optional, default: 1.0)
    - `-b, --brightness_boost <float>`: increase/decrease perceived brightness (optional, default: 1.0)
+   
    advanced options (your image will break, probably, but you might get some cool results):
    - `    --full_characters`: Uses full spectrum of characters in image.
    - `    --ascii_chars <string>`: Use what characters you want to use in the image. (default: " .:-=+*%@#")
    - `    --disable_sort`: Prevents sorting of the ascii_chars by size.
    - `    --block_size <u8>`: Set the size of the blocks. (default: 8)
    - `    --threshold_disabled`: Disables the threshold.
+
+   set a custom color value
+   - `    --custom_color`: Enables custom color from the --r, --g, --b parameters
+   - `    --r`: Sets the r color.
+   - `    --g`: Sets the g color.
+   - `    --b`: Sets the b color.
 
 2. examples:
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -835,12 +835,26 @@ fn calculateAverageColor(block_info: BlockInfo, args: Args) [3]u8 {
         }
     } else {
         if (args.custom_color) {
-            const color = [3]u8{
-                args.r,
-                args.g,
-                args.b,
-            };
-            return color;
+            if (args.invert_color) {
+                var color = [3]u8{
+                    args.r,
+                    args.g,
+                    args.b,
+                };
+                if (args.invert_color) {
+                    color[0] = 255 - color[0];
+                    color[1] = 255 - color[1];
+                    color[2] = 255 - color[2];
+                }
+                return color;
+            } else {
+                const color = [3]u8{
+                    args.r,
+                    args.g,
+                    args.b,
+                };
+                return color;
+            }
         } else {
             return .{ 255, 255, 255 };
         }


### PR DESCRIPTION
Advanced color settings:
   - `    --custom_color`: Enables custom color for the image from the --r, --g, --b parameters
   - `    --r <int>`: Sets the r color.
   - `    --g <int>`: Sets the g color.
   - `    --b <int>`: Sets the b color.
   - `    --background_color`: Enables background color for the image from the --r_bg, --g_bg, --b_bg parameters
   - `    --r_bg <int>`: Sets the r color of the background.
   - `    --g_bg <int>`: Sets the g color of the background.
   - `    --b_bg <int>`: Sets the b color of the background.